### PR TITLE
Add cache key generation test

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -96,6 +96,12 @@ class ApiService {
     return '$endpoint?$queryString';
   }
 
+  /// Public wrapper around [_generateCacheKey] for testing purposes.
+  @visibleForTesting
+  String generateCacheKeyForTest(String endpoint, Map<String, dynamic>? queryParams) {
+    return _generateCacheKey(endpoint, queryParams);
+  }
+
 
   /// Generic GET request with caching.
   Future<T> _get<T>(

--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shorouk_news/services/api_service.dart';
+
+void main() {
+  group('ApiService.generateCacheKeyForTest', () {
+    test('parameter order does not affect generated key', () {
+      final service = ApiService();
+      const endpoint = 'sample/endpoint';
+      final params1 = {'a': '1', 'b': '2', 'c': '3'};
+      final params2 = {'c': '3', 'a': '1', 'b': '2'};
+
+      final key1 = service.generateCacheKeyForTest(endpoint, params1);
+      final key2 = service.generateCacheKeyForTest(endpoint, params2);
+
+      expect(key1, equals(key2));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- expose `generateCacheKeyForTest` in ApiService for testing
- add unit test for ApiService cache key generation

## Testing
- `flutter test test/api_service_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405068ef6c8321aca0507154aed153