### PR TITLE
Add base services and constants

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,0 +1,3 @@
+class AppConstants {
+  static const String baseUrl = '<your base url>';
+}

--- a/lib/screens/columns/columns_module.dart
+++ b/lib/screens/columns/columns_module.dart
@@ -9,9 +9,9 @@ import '../../models/column_model.dart';
 import '../../models/author_model.dart';
 import '../../models/additional_models.dart';
 import '../../core/constants.dart';
-import '../../core/api_service.dart';
-import '../../core/cache_manager.dart';
-import '../../core/analytics_service.dart';
+import '../../services/api_service.dart';
+import '../../services/cache_manager.dart';
+import '../../services/analytics_service.dart';
 
 class ColumnsModule {
   static const String _moduleName = 'ColumnsModule';

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+class AnalyticsService {
+  static final AnalyticsService _instance = AnalyticsService._internal();
+
+  factory AnalyticsService() => _instance;
+  AnalyticsService._internal();
+
+  Future<void> logEvent(String name, {Map<String, dynamic>? parameters}) async {
+    debugPrint('Analytics event: $name, params: $parameters');
+  }
+}

--- a/lib/services/cache_manager.dart
+++ b/lib/services/cache_manager.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CacheManager {
+  static const String _prefix = 'cache_';
+  static final CacheManager _instance = CacheManager._internal();
+
+  factory CacheManager() => _instance;
+  CacheManager._internal();
+
+  Future<dynamic> get(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? data = prefs.getString('$_prefix$key');
+    if (data == null) return null;
+    try {
+      return jsonDecode(data);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> set(String key, dynamic value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('$_prefix$key', jsonEncode(value));
+  }
+
+  Future<void> remove(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('$_prefix$key');
+  }
+
+  Future<void> removeExpired({Duration expiration = const Duration(hours: 24)}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix));
+    for (final key in keys) {
+      final String? data = prefs.getString(key);
+      if (data == null) continue;
+      try {
+        final decoded = jsonDecode(data);
+        if (decoded is Map && decoded['timestamp'] != null) {
+          final ts = DateTime.tryParse(decoded['timestamp'].toString());
+          if (ts == null || now.difference(ts) > expiration) {
+            await prefs.remove(key);
+          }
+        }
+      } catch (_) {
+        await prefs.remove(key);
+      }
+    }
+  }
+
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix)).toList();
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple `CacheManager` for storing cached items
- implement lightweight `AnalyticsService`
- introduce `AppConstants` with a baseUrl placeholder
- fix `ColumnsModule` imports to reference new services

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f82e1ec08321b8bb7399128bf186