### PR TITLE
Fix inappwebview build error

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,3 +87,7 @@ flutter:
           weight: 400
         - asset: assets/fonts/Tajawal-Bold.ttf
           weight: 700
+
+dependency_overrides:
+  flutter_inappwebview: ^6.0.0
+


### PR DESCRIPTION
## Summary
- override `flutter_inappwebview` with a version that defines android namespace

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848074fb8308321a99021abb3233b67