### PR TITLE
Enable core library desugaring

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
 }


### PR DESCRIPTION
## Summary
- enable desugaring in `compileOptions`
- add desugar library dependency for Android

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68480971ad708321bf08b394d38d93d0