### PR TITLE
Fix XML parse error in Android resources

### DIFF
--- a/android/app/src/main/res/xml/gma_ad_services_config.xml
+++ b/android/app/src/main/res/xml/gma_ad_services_config.xml
@@ -1,5 +1,4 @@
-<!--
 <?xml version="1.0" encoding="utf-8"?>
 <ad-services-config>
     <property name="gms:ads:privacy:privacy_sandbox_enabled" value="true"/>
-</ad-services-config>-->
+</ad-services-config>


### PR DESCRIPTION
## Summary
- remove erroneous comment wrapper from `gma_ad_services_config.xml`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6848177c3fb4832191074996b0105cbb