### PR TITLE
Fix Android build by removing gma config

### DIFF
--- a/android/app/src/main/res/xml/gma_ad_services_config.xml
+++ b/android/app/src/main/res/xml/gma_ad_services_config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ad-services-config>
-    <property name="gms:ads:privacy:privacy_sandbox_enabled" value="true"/>
-</ad-services-config>


### PR DESCRIPTION
## Summary
- remove leftover `gma_ad_services_config.xml` which was causing XML parse failures

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684818b575748321b69f8bf78925fc42