### PR TITLE
Fix provider rebuild during build

### DIFF
--- a/lib/widgets/main_layout.dart
+++ b/lib/widgets/main_layout.dart
@@ -25,7 +25,9 @@ class _MainLayoutState extends State<MainLayout> {
   @override
   void initState() {
     super.initState();
-    _loadSections();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadSections();
+    });
   }
 
   Future<void> _loadSections() async {


### PR DESCRIPTION
## Summary
- avoid calling NewsProvider during MainLayout build by deferring `_loadSections`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e4191d08321b96e56bfe1c744fa