### PR TITLE
Fix scaffold assertion by disposing controllers

### DIFF
--- a/lib/screens/columns/column_detail_screen.dart
+++ b/lib/screens/columns/column_detail_screen.dart
@@ -121,6 +121,12 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/gallery/image_viewer_screen.dart
+++ b/lib/screens/gallery/image_viewer_screen.dart
@@ -64,6 +64,12 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
   }
 
   @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final currentPhoto =
         widget.photos.isNotEmpty && _currentIndex < widget.photos.length

--- a/lib/screens/gallery/photo_gallery_screen.dart
+++ b/lib/screens/gallery/photo_gallery_screen.dart
@@ -123,6 +123,12 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen> {
   }
 
   @override
+  void dispose() {
+    _galleryModule.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -60,6 +60,12 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 

--- a/lib/screens/news/news_detail_screen.dart
+++ b/lib/screens/news/news_detail_screen.dart
@@ -152,6 +152,12 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
     }
   }
 
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   /// Navigates to the photo gallery screen.
   void _showPhotoGallery(int initialIndex) {
     if (_newsDetail?.relatedPhotos.isEmpty ?? true) return;


### PR DESCRIPTION
## Summary
- dispose `ScrollController` in `HomeScreen`
- dispose controllers in `ColumnDetailScreen`, `NewsDetailScreen`, `ImageViewerScreen`
- dispose gallery module in `PhotoGalleryScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aa93d5310832185cf3aa1e03bab58