### PR TITLE
Fix scaffold assertion by disposing controllers

### DIFF
--- a/lib/screens/columns/column_detail_screen.dart
+++ b/lib/screens/columns/column_detail_screen.dart
@@ -121,6 +121,12 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -397,13 +403,12 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
 
   Widget _buildRelatedColumns() {
     if (_isLoadingRelated) {
-      return const SliverToBoxAdapter(
-          child: Center(child: CircularProgressIndicator()));
+      return const Center(child: CircularProgressIndicator());
     }
-    if (_relatedColumns.isEmpty) return const SliverToBoxAdapter(child: SizedBox.shrink());
+    if (_relatedColumns.isEmpty) return const SizedBox.shrink();
 
-    return SliverList(
-      delegate: SliverChildListDelegate([
+    return Column(
+      children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
           child: SectionHeader(
@@ -416,10 +421,9 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
         ListView.builder(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          itemCount: _relatedColumns.take(3).length, // Show up to 3 related
+          itemCount: _relatedColumns.take(3).length,
           itemBuilder: (context, index) {
             final column = _relatedColumns[index];
-            // Using a simplified card for related columns
             return Card(
               margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
               child: ListTile(
@@ -440,7 +444,7 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
           },
         ),
         const SizedBox(height: 16),
-      ]),
+      ],
     );
   }
 }

--- a/lib/screens/gallery/image_viewer_screen.dart
+++ b/lib/screens/gallery/image_viewer_screen.dart
@@ -64,6 +64,12 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
   }
 
   @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final currentPhoto =
         widget.photos.isNotEmpty && _currentIndex < widget.photos.length

--- a/lib/screens/gallery/photo_gallery_screen.dart
+++ b/lib/screens/gallery/photo_gallery_screen.dart
@@ -123,6 +123,12 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen> {
   }
 
   @override
+  void dispose() {
+    _galleryModule.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -60,6 +60,12 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 

--- a/lib/screens/news/news_detail_screen.dart
+++ b/lib/screens/news/news_detail_screen.dart
@@ -152,6 +152,12 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
     }
   }
 
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   /// Navigates to the photo gallery screen.
   void _showPhotoGallery(int initialIndex) {
     if (_newsDetail?.relatedPhotos.isEmpty ?? true) return;

--- a/lib/widgets/main_layout.dart
+++ b/lib/widgets/main_layout.dart
@@ -19,7 +19,6 @@ class MainLayout extends StatefulWidget {
 }
 
 class _MainLayoutState extends State<MainLayout> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   List<NewsSection> sections = [];
 
   @override
@@ -48,7 +47,6 @@ class _MainLayoutState extends State<MainLayout> {
     final isHome = currentLocation == '/home';
 
     return Scaffold(
-      key: _scaffoldKey,
       appBar: AppBar(
         title: GestureDetector(
           onTap: () {
@@ -75,9 +73,11 @@ class _MainLayoutState extends State<MainLayout> {
             },
           ),
         ),
-        leading: IconButton(
-          icon: const Icon(Icons.menu),
-          onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
         ),
         actions: [
           if (!isHome)


### PR DESCRIPTION
## Summary
- dispose `ScrollController` in `HomeScreen`
- dispose controllers in `ColumnDetailScreen`, `NewsDetailScreen`, `ImageViewerScreen`
- dispose gallery module in `PhotoGalleryScreen`
- remove duplicate GlobalKey from `MainLayout` and fix sliver error in `ColumnDetailScreen`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684aa93d5310832185cf3aa1e03bab58