### PR TITLE
Fix sliver type in ColumnDetail

### DIFF
--- a/lib/screens/columns/column_detail_screen.dart
+++ b/lib/screens/columns/column_detail_screen.dart
@@ -179,10 +179,7 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
                       SliverToBoxAdapter(
                         child: _buildShareSection(),
                       ),
-                      if (_relatedColumns.isNotEmpty)
-                        SliverToBoxAdapter(
-                          child: _buildRelatedColumns(),
-                        ),
+                      ..._buildRelatedColumnsSlivers(),
                         // const SliverToBoxAdapter(
                         //   child: AdBanner(
                         //       adUnit: '/21765378867/ShorouknewsApp_Banner2'),
@@ -401,15 +398,21 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
     );
   }
 
-  Widget _buildRelatedColumns() {
+  List<Widget> _buildRelatedColumnsSlivers() {
     if (_isLoadingRelated) {
-      return const Center(child: CircularProgressIndicator());
+      return const [
+        SliverToBoxAdapter(
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      ];
     }
-    if (_relatedColumns.isEmpty) return const SizedBox.shrink();
+    if (_relatedColumns.isEmpty) return [];
 
-    return Column(
-      children: [
-        Padding(
+    final columns = _relatedColumns.take(3).toList();
+
+    return [
+      SliverToBoxAdapter(
+        child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
           child: SectionHeader(
             title: 'المزيد من مقالات الكاتب',
@@ -418,12 +421,11 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
                 context.go('/columns?columnistId=${_columnDetail!.columnistId}'),
           ),
         ),
-        ListView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: _relatedColumns.take(3).length,
-          itemBuilder: (context, index) {
-            final column = _relatedColumns[index];
+      ),
+      SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) {
+            final column = columns[index];
             return Card(
               margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
               child: ListTile(
@@ -442,9 +444,10 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
               ),
             );
           },
+          childCount: columns.length,
         ),
-        const SizedBox(height: 16),
-      ],
-    );
+      ),
+      const SliverToBoxAdapter(child: SizedBox(height: 16)),
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- use `_buildRelatedColumnsSlivers` in `ColumnDetailScreen`
- render related columns using `SliverList` instead of `ListView`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aacfa664c832185a8b41f4e0582e1