### PR TITLE
Ensure screens use central theme

### DIFF
--- a/lib/screens/gallery/image_viewer_screen.dart
+++ b/lib/screens/gallery/image_viewer_screen.dart
@@ -4,6 +4,8 @@ import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../core/theme.dart';
+
 import '../../models/new_model.dart'; // For RelatedPhoto
 
 class ImageViewerScreen extends StatefulWidget {
@@ -103,7 +105,7 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
                   width: 30.0,
                   height: 30.0,
                   child: CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white70),
+                    valueColor: AlwaysStoppedAnimation<Color>(AppTheme.primaryColor),
                   ),
                 ),
               ),
@@ -123,15 +125,15 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
                   // ignore: deprecated_member_use
                   backgroundColor: Colors.black.withOpacity(0.5),
                   elevation: 0,
-                  iconTheme: const IconThemeData(color: Colors.white),
+                  iconTheme: const IconThemeData(color: AppTheme.textOnPrimary),
                   title: Text(
                     widget.galleryTitle ?? 'عارض الصور',
-                    style: const TextStyle(color: Colors.white, fontSize: 18),
+                    style: const TextStyle(color: AppTheme.textOnPrimary, fontSize: 18),
                   ),
                   actions: [
                     IconButton(
                       icon:
-                          const Icon(Icons.share_outlined, color: Colors.white),
+                          const Icon(Icons.share_outlined, color: AppTheme.textOnPrimary),
                       onPressed: _shareCurrentImage,
                       tooltip: 'مشاركة الصورة',
                     ),
@@ -142,7 +144,7 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
                         child: Text(
                           '${_currentIndex + 1} / ${widget.photos.length}',
                           style: const TextStyle(
-                              color: Colors.white, fontSize: 16),
+                              color: AppTheme.textOnPrimary, fontSize: 16),
                         ),
                       ),
                     ),
@@ -164,7 +166,7 @@ class _ImageViewerScreenState extends State<ImageViewerScreen> {
                       currentPhoto.photoCaption,
                       textAlign: TextAlign.center,
                       style: const TextStyle(
-                        color: Colors.white,
+                        color: AppTheme.textOnPrimary,
                         fontSize: 14.0,
                       ),
                     ),

--- a/lib/screens/terms/terms_screen.dart
+++ b/lib/screens/terms/terms_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/theme.dart';
+
 class TermsScreen extends StatelessWidget {
   const TermsScreen({super.key});
 
@@ -9,77 +11,70 @@ class TermsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Terms of Service'),
       ),
-      body: const SingleChildScrollView(
-        padding: EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              'Terms of Service',
-              style: TextStyle(
-                fontSize: 24.0,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 16.0),
-            Text(
-              'Please read these Terms of Service carefully before using our application.',
-              style: TextStyle(fontSize: 16.0),
-            ),
-            SizedBox(height: 16.0),
-            Text(
-              '1. Acceptance of Terms',
-              style: TextStyle(
-                fontSize: 20.0,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 8.0),
-            Text(
-              'By accessing or using the application, you agree to be bound by these Terms of Service and all terms incorporated by reference. If you do not agree to all of these terms, do not use the application.',
-              style: TextStyle(fontSize: 16.0),
-            ),
-            SizedBox(height: 16.0),
-            Text(
-              '2. Changes to Terms',
-              style: TextStyle(
-                fontSize: 20.0,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 8.0),
-            Text(
-              'We reserve the right to change or modify these Terms of Service at any time and in our sole discretion. If we make changes, we will provide notice of such changes, such as by sending an email notification, providing notice through the application, or updating the "Last Updated" date at the top of these Terms of Service. Your continued use of the application will confirm your acceptance of the revised Terms of Service. We encourage you to frequently review the Terms of Service to ensure you understand the terms and conditions that apply to your use of the application.',
-              style: TextStyle(fontSize: 16.0),
-            ),
-            SizedBox(height: 16.0),
-            Text(
-              '3. Privacy Policy',
-              style: TextStyle(
-                fontSize: 20.0,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 8.0),
-            Text(
-              'Please refer to our Privacy Policy for information about how we collect, use, and disclose information about our users.',
-              style: TextStyle(fontSize: 16.0),
-            ),
-            SizedBox(height: 16.0),
-            Text(
-              '4. Content',
-              style: TextStyle(
-                fontSize: 20.0,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 8.0),
-            Text(
-              'All content on the application, including but not limited to text, graphics, images, and software, is the property of [Your Company Name] or its licensors and is protected by copyright and other intellectual property laws.',
-              style: TextStyle(fontSize: 16.0),
-            ),
-            // Add more terms as needed
-          ],
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Builder(
+          builder: (context) {
+            final textTheme = Theme.of(context).textTheme;
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Terms of Service',
+                  style: textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: AppTheme.primaryColor,
+                  ),
+                ),
+                const SizedBox(height: 16.0),
+                Text(
+                  'Please read these Terms of Service carefully before using our application.',
+                  style: textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16.0),
+                Text(
+                  '1. Acceptance of Terms',
+                  style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8.0),
+                Text(
+                  'By accessing or using the application, you agree to be bound by these Terms of Service and all terms incorporated by reference. If you do not agree to all of these terms, do not use the application.',
+                  style: textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16.0),
+                Text(
+                  '2. Changes to Terms',
+                  style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8.0),
+                Text(
+                  'We reserve the right to change or modify these Terms of Service at any time and in our sole discretion. If we make changes, we will provide notice of such changes, such as by sending an email notification, providing notice through the application, or updating the "Last Updated" date at the top of these Terms of Service. Your continued use of the application will confirm your acceptance of the revised Terms of Service. We encourage you to frequently review the Terms of Service to ensure you understand the terms and conditions that apply to your use of the application.',
+                  style: textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16.0),
+                Text(
+                  '3. Privacy Policy',
+                  style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8.0),
+                Text(
+                  'Please refer to our Privacy Policy for information about how we collect, use, and disclose information about our users.',
+                  style: textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16.0),
+                Text(
+                  '4. Content',
+                  style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8.0),
+                Text(
+                  'All content on the application, including but not limited to text, graphics, images, and software, is the property of [Your Company Name] or its licensors and is protected by copyright and other intellectual property laws.',
+                  style: textTheme.bodyMedium,
+                ),
+                // Add more terms as needed
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/screens/videos/video_detail_screen.dart
+++ b/lib/screens/videos/video_detail_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
+import '../../core/theme.dart';
+
 class VideoDetailScreen extends StatefulWidget {
   final String videoUrl;
   final String videoTitle;
@@ -51,13 +53,18 @@ class _VideoDetailScreenState extends State<VideoDetailScreen> {
       ),
       body: Center(
         child: _isLoading
-            ? const CircularProgressIndicator()
+            ? const CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation(AppTheme.primaryColor),
+              )
             : _controller.value.isInitialized
                 ? AspectRatio(
                     aspectRatio: _controller.value.aspectRatio,
                     child: VideoPlayer(_controller),
                   )
-                : const Text('Error loading video.'),
+                : Text(
+                    'Error loading video.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
@@ -67,6 +74,8 @@ class _VideoDetailScreenState extends State<VideoDetailScreen> {
                 : _controller.play();
           });
         },
+        backgroundColor: AppTheme.tertiaryColor,
+        foregroundColor: Colors.white,
         child: Icon(
           _controller.value.isPlaying ? Icons.pause : Icons.play_arrow,
         ),

--- a/lib/screens/videos/videos_screen.dart
+++ b/lib/screens/videos/videos_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/theme.dart';
+
 class VideosScreen extends StatelessWidget {
   const VideosScreen({super.key});
 
@@ -9,8 +11,13 @@ class VideosScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Videos'),
       ),
-      body: const Center(
-        child: Text('Video Listing Page'),
+      body: Center(
+        child: Text(
+          'Video Listing Page',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: AppTheme.primaryColor,
+              ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- import `theme.dart` in `terms`, `videos` and gallery screens
- apply `AppTheme` colors and text styles to keep consistent branding

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aae97fb948321a6f61046d0b61932