### PR TITLE
Handle iframe content in news detail

### DIFF
--- a/lib/screens/news/news_detail_screen.dart
+++ b/lib/screens/news/news_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_html_iframe/flutter_html_iframe.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:go_router/go_router.dart';
@@ -602,11 +603,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
           ),
         },
         onLinkTap: (url, attributes, element) => _handleLinkTap(url),
-        // Corrected: onImageTap is not a direct parameter.
-        // Image taps can be handled by wrapping images in <a> tags in HTML
-        // or by using customRenders if more complex interaction is needed.
-        // For now, removing the onImageTap directly from Html widget.
-        // If images are wrapped in <a> tags, onLinkTap will handle them.
+        extensions: const [IframeHtmlExtension()],
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  flutter_html_iframe:
+    dependency: "direct main"
+    description:
+      name: flutter_html_iframe
+      sha256: "6da7a76853e1c0a5e0cd5a91236cad842c0d17056a439f966879f485ae0e2ffa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_inappwebview:
     dependency: "direct overridden"
     description:
@@ -476,18 +484,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "88bc797f44a94814f2213db1c9bd5badebafdfb8290ca9f78d4b9ee2a3db4d79"
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "8.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.2.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   
   # HTML rendering
   flutter_html: ^3.0.0-beta.2
+  flutter_html_iframe: ^3.0.0
   
   # Push notifications (disabled)
   # firebase_core: ^2.24.2
@@ -54,7 +55,7 @@ dependencies:
   # Utilities
   intl: ^0.19.0
   connectivity_plus: ^5.0.2
-  package_info_plus: ^5.0.1
+  package_info_plus: ^8.3.0
   device_info_plus: ^9.1.1
   
   # Loading and refresh


### PR DESCRIPTION
## Summary
- add `flutter_html_iframe` dependency
- support iframe rendering for news detail
- update `package_info_plus` to avoid dependency conflict

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8f1fee48321bd4b545d3c15696b