### PR TITLE
Remove duplicate back buttons

### DIFF
--- a/lib/screens/about/about_screen.dart
+++ b/lib/screens/about/about_screen.dart
@@ -167,11 +167,8 @@ class _AboutScreenState extends State<AboutScreen> with TickerProviderStateMixin
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('عن البرنامج'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
         actions: [
           IconButton(
             icon: Icon(_isCheckingUpdates ? Icons.hourglass_empty : Icons.system_update),

--- a/lib/screens/authors/author_screen.dart
+++ b/lib/screens/authors/author_screen.dart
@@ -257,16 +257,7 @@ class _AuthorScreenState extends State<AuthorScreen>
   PreferredSizeWidget _buildAppBar() {
     return AppBar(
       title: Text(_author?.arName ?? 'الكاتب'),
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back),
-        onPressed: () {
-          if (context.canPop()) {
-            context.pop();
-          } else {
-            context.push('/authors');
-          } 
-        },
-      ),
+      automaticallyImplyLeading: false,
       actions: [
         if (_author != null) ...[
           IconButton(

--- a/lib/screens/authors/authors_list_screen.dart
+++ b/lib/screens/authors/authors_list_screen.dart
@@ -373,10 +373,7 @@ class _AuthorsListScreenState extends State<AuthorsListScreen>
   PreferredSizeWidget _buildAppBar() {
     return AppBar(
       title: const Text('الكتّاب'),
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back),
-        onPressed: () => context.pop(),
-      ),
+      automaticallyImplyLeading: false,
       actions: [
         IconButton(
           icon: const Icon(Icons.search),

--- a/lib/screens/columns/columns_screen.dart
+++ b/lib/screens/columns/columns_screen.dart
@@ -513,10 +513,7 @@ class _ColumnsScreenState extends State<ColumnsScreen>
   PreferredSizeWidget _buildAppBar() {
     return AppBar(
       title: Text(_getAppBarTitle()),
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back),
-        onPressed: () => context.pop(),
-      ),
+      automaticallyImplyLeading: false,
       actions: [
         IconButton(
           icon: const Icon(Icons.search),

--- a/lib/screens/contact/contact_screen.dart
+++ b/lib/screens/contact/contact_screen.dart
@@ -118,11 +118,8 @@ class _ContactScreenState extends State<ContactScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('اتصل بنا'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
       ),
       body: SingleChildScrollView(
           child: Column(

--- a/lib/screens/error/error_screen.dart
+++ b/lib/screens/error/error_screen.dart
@@ -26,18 +26,8 @@ class ErrorScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('خطأ'), // Arabic title: "Error"
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            // Navigate back if possible, otherwise go to home
-            if (context.canPop()) {
-              context.pop();
-            } else {
-              context.go('/home');
-            }
-          },
-        ),
       ),
       body: Center(
         child: Padding(

--- a/lib/screens/gallery/photo_gallery_screen.dart
+++ b/lib/screens/gallery/photo_gallery_screen.dart
@@ -132,17 +132,8 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text(widget.galleryTitle ?? 'معرض الصور'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            if (context.canPop()) {
-              context.pop();
-            } else {
-              context.go('/home'); // Fallback to home
-            }
-          },
-        ),
       ),
         body: Column(
           children: [

--- a/lib/screens/newsletter/newsletter_screen.dart
+++ b/lib/screens/newsletter/newsletter_screen.dart
@@ -106,11 +106,8 @@ class _NewsletterScreenState extends State<NewsletterScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('القائمة البريدية'), // "Newsletter"
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
       ),
         body: SingleChildScrollView(
           child: Column(

--- a/lib/screens/privacy/privacy_screen.dart
+++ b/lib/screens/privacy/privacy_screen.dart
@@ -71,11 +71,8 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('سياسة الخصوصية'), // "Privacy Policy"
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
       ),
         body: Column(
         children: [

--- a/lib/screens/search/search_results_screen.dart
+++ b/lib/screens/search/search_results_screen.dart
@@ -177,18 +177,9 @@ class _SearchResultsScreenState extends State<SearchResultsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text('نتائج البحث عن: "${widget.query}"',
             style: const TextStyle(fontSize: 18)),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            if (context.canPop()) {
-              context.pop();
-            } else {
-              context.push('/search'); // Fallback to search screen if cannot pop
-            }
-          },
-        ),
       ),
         body: Column(
           children: [

--- a/lib/screens/search/search_screen.dart
+++ b/lib/screens/search/search_screen.dart
@@ -164,11 +164,8 @@ class _SearchScreenState extends State<SearchScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('البحث في الشروق'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
       ),
         body: Column(
           children: [

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -85,11 +85,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text('ضبط إعدادات الإشعارات'), // "Notification Settings"
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
       ),
         body: Column(
         children: [


### PR DESCRIPTION
## Summary
- avoid placing back buttons inside screens
- rely on header bar for navigation

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc882ff808321bd01d0f27098cec9