### PR TITLE
Improve image caching quality

### DIFF
--- a/lib/screens/authors/authors_list_screen.dart
+++ b/lib/screens/authors/authors_list_screen.dart
@@ -823,6 +823,7 @@ class _AuthorsListScreenState extends State<AuthorsListScreen>
                 child: CachedNetworkImage(
                   imageUrl: author.photoUrl,
                   fit: BoxFit.cover,
+                  filterQuality: FilterQuality.high,
                   placeholder: (context, url) => Container(
                     color: Colors.grey[300],
                     child: const Icon(Icons.person),
@@ -896,6 +897,7 @@ class _AuthorsListScreenState extends State<AuthorsListScreen>
                         child: CachedNetworkImage(
                           imageUrl: author.photoUrl,
                           fit: BoxFit.cover,
+                          filterQuality: FilterQuality.high,
                           placeholder: (context, url) => Container(
                             color: Colors.grey[300],
                             child: const Icon(Icons.person, size: 40),
@@ -1015,6 +1017,7 @@ Widget _buildAuthorListCard(AuthorModel author) {
                         child: CachedNetworkImage(
                           imageUrl: author.photoUrl,
                           fit: BoxFit.cover,
+                          filterQuality: FilterQuality.high,
                           placeholder: (context, url) => Container(
                             color: Colors.grey[300],
                             child: const Icon(Icons.person, size: 30),

--- a/lib/screens/columns/columns_screen.dart
+++ b/lib/screens/columns/columns_screen.dart
@@ -991,6 +991,7 @@ class _ColumnsScreenState extends State<ColumnsScreen>
                   child: CachedNetworkImage(
                     imageUrl: _author!.photoUrl,
                     fit: BoxFit.cover,
+                    filterQuality: FilterQuality.high,
                     placeholder: (context, url) => Container(
                       color: Colors.grey[300],
                       child: const Icon(Icons.person, size: 40),
@@ -1221,6 +1222,7 @@ class _ColumnsScreenState extends State<ColumnsScreen>
                         child: CachedNetworkImage(
                           imageUrl: column.columnistPhotoUrl,
                           fit: BoxFit.cover,
+                          filterQuality: FilterQuality.high,
                           placeholder: (context, url) => Container(
                             color: Colors.grey[300],
                             child: const Icon(Icons.person, size: 20),
@@ -1385,6 +1387,7 @@ class _ColumnsScreenState extends State<ColumnsScreen>
                         child: CachedNetworkImage(
                           imageUrl: column.columnistPhotoUrl,
                           fit: BoxFit.cover,
+                          filterQuality: FilterQuality.high,
                           placeholder: (context, url) => Container(
                             color: Colors.grey[300],
                             child: const Icon(Icons.person, size: 18),
@@ -1545,6 +1548,7 @@ class _ColumnsScreenState extends State<ColumnsScreen>
                         child: CachedNetworkImage(
                           imageUrl: column.columnistPhotoUrl,
                           fit: BoxFit.cover,
+                          filterQuality: FilterQuality.high,
                           placeholder: (context, url) => Container(
                             color: Colors.grey[300],
                             child: const Icon(Icons.person, size: 30),

--- a/lib/screens/gallery/photo_gallery_screen.dart
+++ b/lib/screens/gallery/photo_gallery_screen.dart
@@ -252,6 +252,7 @@ class _PhotoGalleryScreenState extends State<PhotoGalleryScreen> {
                     ? photo.thumbnailPhotoUrl
                     : photo.photoUrl, // Fallback to full photo if thumb is empty
                 fit: BoxFit.cover,
+                filterQuality: FilterQuality.high,
                 placeholder: (context, url) => Shimmer.fromColors(
                   baseColor: Colors.grey[300]!,
                   highlightColor: Colors.grey[100]!,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -237,6 +237,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 child: CachedNetworkImage(
                   imageUrl: mainStory.photoUrl,
                   fit: BoxFit.cover,
+                  filterQuality: FilterQuality.high,
                   placeholder: (context, url) => Shimmer.fromColors(
                     baseColor: AppTheme.dividerColor,
                     highlightColor: AppTheme.surfaceVariant,
@@ -348,6 +349,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     ? story.thumbnailPhotoUrl
                     : story.photoUrl,
                 fit: BoxFit.cover,
+                filterQuality: FilterQuality.high,
                 placeholder: (context, url) => Container(
                   color: Colors.grey[300],
                   child: const Center(
@@ -544,6 +546,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   width: 100,
                   height: 80,
                   fit: BoxFit.cover,
+                  filterQuality: FilterQuality.high,
                   placeholder: (context, url) => Container(
                     width: 100,
                     height: 80,

--- a/lib/screens/news/news_detail_screen.dart
+++ b/lib/screens/news/news_detail_screen.dart
@@ -395,6 +395,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
               child: CachedNetworkImage(
                 imageUrl: _newsDetail!.photoUrl,
                 fit: BoxFit.cover,
+                filterQuality: FilterQuality.high,
                 placeholder: (context, url) => Shimmer.fromColors(
                   baseColor: Colors.grey[300]!,
                   highlightColor: Colors.grey[100]!,
@@ -669,6 +670,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
                                 ? photo.thumbnailPhotoUrl
                                 : photo.photoUrl,
                             fit: BoxFit.cover,
+                            filterQuality: FilterQuality.high,
                             placeholder: (context, url) => Shimmer.fromColors(
                                 baseColor: Colors.grey[300]!,
                                 highlightColor: Colors.grey[100]!,

--- a/lib/widgets/news_card.dart
+++ b/lib/widgets/news_card.dart
@@ -116,6 +116,7 @@ class NewsCard extends StatelessWidget {
                 width: 100,
                 height: 80,
                 fit: BoxFit.cover,
+                filterQuality: FilterQuality.high,
                 placeholder: (context, url) => Container(
                   width: 100,
                   height: 80,
@@ -167,6 +168,7 @@ class NewsCard extends StatelessWidget {
                   CachedNetworkImage(
                     imageUrl: article.photoUrl,
                     fit: BoxFit.cover,
+                    filterQuality: FilterQuality.high,
                     placeholder: (context, url) => Container(
                       color: AppTheme.surfaceVariant,
                       child: const Center(


### PR DESCRIPTION
## Summary
- ensure `CachedNetworkImage` uses `FilterQuality.high` so cached images render sharply

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd3420c0483218c793ec1a916495a