### PR TITLE
Enable column preview via card long press

### DIFF
--- a/lib/screens/authors/author_screen.dart
+++ b/lib/screens/authors/author_screen.dart
@@ -781,9 +781,10 @@ class _AuthorScreenState extends State<AuthorScreen>
 
     return NewsCard(
       article: tempArticleForCard,
-      isHorizontal: true, 
+      isHorizontal: true,
       onTap: () => context.push('/column/${column.cDate}/${column.id}'),
-      showDate: true, 
+      onLongPress: () => _showColumnPreview(column),
+      showDate: true,
     );
   }
 

--- a/lib/widgets/news_card.dart
+++ b/lib/widgets/news_card.dart
@@ -8,6 +8,7 @@ import '../core/theme.dart';
 class NewsCard extends StatelessWidget {
   final NewsArticle article;
   final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
   final bool isHorizontal;
   final bool showDate;
 
@@ -15,6 +16,7 @@ class NewsCard extends StatelessWidget {
     super.key,
     required this.article,
     this.onTap,
+    this.onLongPress,
     this.isHorizontal = false,
     this.showDate = true,
   });
@@ -31,6 +33,7 @@ class NewsCard extends StatelessWidget {
   Widget _buildHorizontalCard(BuildContext context) {
     return InkWell(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.all(12),
         decoration: const BoxDecoration(
@@ -156,6 +159,7 @@ class NewsCard extends StatelessWidget {
       ),
       child: InkWell(
         onTap: onTap,
+        onLongPress: onLongPress,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [


### PR DESCRIPTION
## Summary
- allow `NewsCard` to support `onLongPress`
- open column preview from author screen when long pressing a column card

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd61bce10832191f82584461c93ed