### PR TITLE
Add Firebase messaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Push Notifications
+
+This project integrates Firebase Cloud Messaging together with
+`flutter_local_notifications` to display notifications when messages arrive.
+Ensure you have added the appropriate Firebase configuration files for each
+platform before building the app.

--- a/lib/core/app_router.dart
+++ b/lib/core/app_router.dart
@@ -20,6 +20,9 @@ import '../screens/search/search_screen.dart'; // Assumes this contains the Sear
 import '../screens/search/search_results_screen.dart'; // Assumes this contains SearchResultsScreen
 import '../screens/gallery/photo_gallery_screen.dart';
 import '../screens/gallery/image_viewer_screen.dart';
+import '../screens/notifications/notifications_screen.dart';
+import '../screens/notifications/notification_detail_screen.dart';
+import '../services/notification_service.dart' show NotificationPayload;
 import '../screens/error/error_screen.dart';
 
 // Import models if passed via 'extra'
@@ -154,6 +157,22 @@ class AppRouter {
             path: '/privacy',
             name: 'privacy',
             builder: (context, state) => const PrivacyScreen(),
+          ),
+          GoRoute(
+            path: '/notifications',
+            name: 'notifications',
+            builder: (context, state) => const NotificationsScreen(),
+          ),
+          GoRoute(
+            path: '/notification-detail',
+            name: 'notification-detail',
+            builder: (context, state) {
+              final payload = state.extra as NotificationPayload?;
+              if (payload != null) {
+                return NotificationDetailScreen(notification: payload);
+              }
+              return const ErrorScreen(errorMessage: 'بيانات الإشعار غير متوفرة');
+            },
           ),
           GoRoute(
             path: '/search',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-// import 'package:firebase_core/firebase_core.dart';
-// import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 // import 'package:google_mobile_ads/google_mobile_ads.dart';
 
 import 'core/app_router.dart';
@@ -10,24 +10,25 @@ import 'core/theme.dart';
 import 'providers/news_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/auth_provider.dart';
+import 'services/firebase_service.dart';
+import 'services/notification_service.dart';
 
-// Firebase background message handler (disabled)
-// Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-//   await Firebase.initializeApp();
-//   print("Handling a background message: ${message.messageId}");
-// }
+// Firebase background message handler
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+  await FirebaseService().initialize();
+}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Initialize Firebase (disabled)
-  // await Firebase.initializeApp();
+  await FirebaseService().initialize();
+  await NotificationService().initialize();
 
   // Initialize Mobile Ads
   // MobileAds.instance.initialize();
 
-  // Set up Firebase messaging (disabled)
-  // FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   // Set preferred orientations
   SystemChrome.setPreferredOrientations([

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -1,29 +1,61 @@
 import 'package:flutter/foundation.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'notification_service.dart';
 
-
-/// Stubbed FirebaseService with Firebase functionality disabled.
+/// Wrapper around Firebase Messaging functionality used in the app.
 class FirebaseService {
   static final FirebaseService _instance = FirebaseService._internal();
   factory FirebaseService() => _instance;
   FirebaseService._internal();
 
-
+  final FirebaseMessaging _messaging = FirebaseMessaging.instance;
   String? _fcmToken;
 
   String? get fcmToken => _fcmToken;
 
+  /// Initializes Firebase and Firebase Messaging.
   Future<void> initialize() async {
-    debugPrint('FirebaseService disabled: initialize called');
+    try {
+      await Firebase.initializeApp();
+
+      NotificationSettings settings = await _messaging.requestPermission();
+      debugPrint('Firebase Messaging permission status: ${settings.authorizationStatus}');
+
+      _fcmToken = await _messaging.getToken();
+      debugPrint('FCM Token: $_fcmToken');
+
+      FirebaseMessaging.onMessage.listen(_handleMessage);
+      FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+    } catch (e) {
+      debugPrint('Error initializing FirebaseService: $e');
+    }
   }
 
+  /// Subscribes the device to a list of FCM topics.
   Future<void> subscribeToTopics(List<String> topics) async {
-    debugPrint('FirebaseService disabled: subscribeToTopics \$topics');
+    for (final topic in topics) {
+      try {
+        await _messaging.subscribeToTopic(topic);
+      } catch (e) {
+        debugPrint('Failed to subscribe to $topic: $e');
+      }
+    }
+    await _saveSubscribedTopicsToLocal(topics);
   }
 
+  /// Unsubscribes the device from the specified FCM topics.
   Future<void> unsubscribeFromTopics(List<String> topics) async {
-    debugPrint('FirebaseService disabled: unsubscribeFromTopics \$topics');
+    for (final topic in topics) {
+      try {
+        await _messaging.unsubscribeFromTopic(topic);
+      } catch (e) {
+        debugPrint('Failed to unsubscribe from $topic: $e');
+      }
+    }
+    await _saveSubscribedTopicsToLocal([]);
   }
 
   Future<List<String>> getSubscribedTopicsFromLocal() async {
@@ -31,25 +63,61 @@ class FirebaseService {
     return prefs.getStringList('user_subscribed_fcm_topics') ?? [];
   }
 
-  Future<void> saveSubscribedTopicsToLocal(List<String> topics) async {
+  Future<void> _saveSubscribedTopicsToLocal(List<String> topics) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setStringList('user_subscribed_fcm_topics', topics);
   }
 
   Future<void> logAnalyticsEvent(String name, {Map<String, Object?>? parameters}) async {
-    debugPrint('FirebaseService disabled: logAnalyticsEvent \$name');
+    debugPrint('Analytics event: $name, params: $parameters');
   }
 
   Future<void> logAnalyticsScreenView(String screenName) async {
-    debugPrint('FirebaseService disabled: logAnalyticsScreenView \$screenName');
+    debugPrint('Analytics screen view: $screenName');
   }
 
   Future<void> announceUserForVersionTracking() async {
-    debugPrint('FirebaseService disabled: announceUserForVersionTracking');
+    debugPrint('announceUserForVersionTracking called');
   }
 
   Future<String?> refreshToken() async {
-    debugPrint('FirebaseService disabled: refreshToken');
-    return _fcmToken;
+    try {
+      _fcmToken = await _messaging.getToken();
+      return _fcmToken;
+    } catch (e) {
+      debugPrint('Error getting FCM token: $e');
+      return null;
+    }
+  }
+
+  /// Handles foreground messages by showing a local notification.
+  Future<void> _handleMessage(RemoteMessage message) async {
+    final notification = message.notification;
+    final data = message.data;
+    if (notification != null) {
+      await NotificationService().showNotification(
+        title: notification.title ?? 'إشعار جديد',
+        body: notification.body ?? '',
+        imageUrl: notification.android?.imageUrl ?? notification.apple?.imageUrl,
+        data: data,
+        isBreakingNews: data['type'] == 'breaking',
+      );
+    }
+  }
+}
+
+/// Top level background message handler used by Firebase Messaging.
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+  final notification = message.notification;
+  final data = message.data;
+  if (notification != null) {
+    await NotificationService().showNotification(
+      title: notification.title ?? 'إشعار جديد',
+      body: notification.body ?? '',
+      imageUrl: notification.android?.imageUrl ?? notification.apple?.imageUrl,
+      data: data,
+      isBreakingNews: data['type'] == 'breaking',
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,9 +35,9 @@ dependencies:
   flutter_html: ^3.0.0-beta.2
   flutter_html_iframe: ^3.0.0
   
-  # Push notifications (disabled)
-  # firebase_core: ^2.24.2
-  # firebase_messaging: ^14.7.9
+  # Push notifications
+  firebase_core: ^2.24.2
+  firebase_messaging: ^14.7.9
   # firebase_analytics: ^10.7.4
   
   # Social sharing


### PR DESCRIPTION
## Summary
- integrate Firebase Cloud Messaging
- hook up background handler and notification service
- add notifications routes
- document push notifications

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fda5404908321805be824b86bd8e3