### PR TITLE
Fix missing method in FirebaseService

### DIFF
--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -63,6 +63,13 @@ class FirebaseService {
     return prefs.getStringList('user_subscribed_fcm_topics') ?? [];
   }
 
+  /// Persists the list of subscribed topics locally so that other
+  /// parts of the app can update the cache without performing FCM
+  /// operations.
+  Future<void> saveSubscribedTopicsToLocal(List<String> topics) async {
+    await _saveSubscribedTopicsToLocal(topics);
+  }
+
 
   Future<void> _saveSubscribedTopicsToLocal(List<String> topics) async {
     final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- add a public `saveSubscribedTopicsToLocal` wrapper in `FirebaseService`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe0c4ef548321a761a8aeef92b893