### PR TITLE
Integrate Firebase In-App Messaging

### DIFF
--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'notification_service.dart';
@@ -21,6 +22,8 @@ class FirebaseService {
     try {
       await Firebase.initializeApp();
       _messaging = FirebaseMessaging.instance;
+      // Initialize Firebase In-App Messaging
+      FirebaseInAppMessaging.instance.triggerEvent('app_launch');
 
       NotificationSettings settings = await _messaging.requestPermission();
       debugPrint('Firebase Messaging permission status: ${settings.authorizationStatus}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   # Push notifications
   firebase_core: ^2.24.2
   firebase_messaging: ^14.7.9
+  firebase_in_app_messaging: ^0.8.1+7
   # firebase_analytics: ^10.7.4
   
   # Social sharing


### PR DESCRIPTION
## Summary
- add `firebase_in_app_messaging` plugin
- initialize the plugin when Firebase starts

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685000bca5688321ba2a8488da2d14c6