### PR TITLE
Fix Firebase initialization by adding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ This project integrates Firebase Cloud Messaging together with
 `flutter_local_notifications` to display notifications when messages arrive.
 Ensure you have added the appropriate Firebase configuration files for each
 platform before building the app.
+
+The repository includes a `lib/firebase_options.dart` file with placeholder
+values. Replace these placeholders with your actual Firebase project settings
+or regenerate the file using the FlutterFire CLI:
+
+```bash
+flutterfire configure
+```
+
+After updating the configuration, rebuild the application.

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,62 @@
+// TODO: Replace placeholder values with your Firebase project configuration
+// This file is intentionally minimal to avoid exposing sensitive information.
+// You can generate a complete file using the FlutterFire CLI.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'YOUR_WEB_API_KEY',
+    appId: 'YOUR_WEB_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    authDomain: 'YOUR_PROJECT_ID.firebaseapp.com',
+    storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+    measurementId: 'YOUR_MEASUREMENT_ID',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'YOUR_ANDROID_API_KEY',
+    appId: 'YOUR_ANDROID_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'YOUR_IOS_API_KEY',
+    appId: 'YOUR_IOS_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+    iosBundleId: 'com.example.shorouk_news',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'YOUR_MACOS_API_KEY',
+    appId: 'YOUR_MACOS_APP_ID',
+    messagingSenderId: 'YOUR_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_PROJECT_ID.appspot.com',
+    iosBundleId: 'com.example.shorouk_news',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 // import 'package:google_mobile_ads/google_mobile_ads.dart';
 
@@ -15,7 +16,9 @@ import 'services/notification_service.dart';
 
 // Firebase background message handler
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   await FirebaseService().initialize();
 }
 

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
+import '../firebase_options.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,7 +21,9 @@ class FirebaseService {
   /// Initializes Firebase and Firebase Messaging.
   Future<void> initialize() async {
     try {
-      await Firebase.initializeApp();
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
       _messaging = FirebaseMessaging.instance;
       // Initialize Firebase In-App Messaging
       FirebaseInAppMessaging.instance.triggerEvent('app_launch');
@@ -120,7 +123,9 @@ class FirebaseService {
 
 /// Top level background message handler used by Firebase Messaging.
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   final notification = message.notification;
   final data = message.data;
   if (notification != null) {


### PR DESCRIPTION
## Summary
- add a `firebase_options.dart` placeholder to allow initialization without Android resources
- initialize Firebase with `DefaultFirebaseOptions.currentPlatform`
- document Firebase configuration in README

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_685017bf79f08321bcf9dc6515639721