### PR TITLE
Remove settings button from drawer

### DIFF
--- a/lib/widgets/main_layout.dart
+++ b/lib/widgets/main_layout.dart
@@ -135,28 +135,7 @@ class _MainLayoutState extends State<MainLayout> {
                   },
                 ),
                 const SizedBox(height: 20),
-                Container(
-                  decoration: BoxDecoration(
-                    color: AppTheme.tertiaryColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: TextButton.icon(
-                    onPressed: () {
-                      // Close drawer first
-                      Navigator.of(context).pop();
-                      // Then navigate
-                      context.push('/settings');
-                    },
-                    icon: const Icon(Icons.settings, color: Colors.white),
-                    label: const Text(
-                      'الإعدادات',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
+                const SizedBox(height: 40),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- remove the "الإعدادات" button from the drawer header

## Testing
- `dart --version` *(fails: command not found)*
- `flutter format lib/widgets/main_layout.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515325ccdc8321bd94d566eed79194