### PR TITLE
Add weather gadget with location permission

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/theme.dart';
 import 'providers/news_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/auth_provider.dart';
+import 'providers/weather_provider.dart';
 import 'services/local_search_service.dart';
 
 
@@ -43,6 +44,7 @@ class ShoroukNewsApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => NewsProvider()),
         ChangeNotifierProvider(create: (_) => SettingsProvider()),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => WeatherProvider()),
       ],
       child: Consumer<SettingsProvider>(
         builder: (context, settingsProvider, child) {

--- a/lib/models/weather_model.dart
+++ b/lib/models/weather_model.dart
@@ -1,0 +1,14 @@
+class WeatherInfo {
+  final double temperature;
+  final int weatherCode;
+
+  WeatherInfo({required this.temperature, required this.weatherCode});
+
+  factory WeatherInfo.fromJson(Map<String, dynamic> json) {
+    final current = json['current_weather'] as Map<String, dynamic>?;
+    return WeatherInfo(
+      temperature: (current?['temperature'] ?? 0).toDouble(),
+      weatherCode: (current?['weathercode'] ?? 0).toInt(),
+    );
+  }
+}

--- a/lib/providers/weather_provider.dart
+++ b/lib/providers/weather_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../models/weather_model.dart';
+import '../services/weather_service.dart';
+
+class WeatherProvider extends ChangeNotifier {
+  final WeatherService _service = WeatherService();
+
+  WeatherInfo? _info;
+  bool _isLoading = false;
+
+  WeatherInfo? get info => _info;
+  bool get isLoading => _isLoading;
+
+  Future<void> requestWeatherForCurrentLocation() async {
+    try {
+      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) return;
+      LocationPermission permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+        if (permission == LocationPermission.denied ||
+            permission == LocationPermission.deniedForever) {
+          return;
+        }
+      }
+      _isLoading = true;
+      notifyListeners();
+      final position = await Geolocator.getCurrentPosition(
+          desiredAccuracy: LocationAccuracy.low);
+      _info = await _service.fetchWeather(
+          position.latitude, position.longitude);
+    } catch (_) {
+      // ignore errors
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -6,9 +6,11 @@ import 'package:shimmer/shimmer.dart';
 
 // Provider for fetching news and column data
 import '../../providers/news_provider.dart';
+import '../../providers/weather_provider.dart';
 
 // Data models for news articles and columns
 import 'package:shorouk_news/models/new_model.dart';
+import '../../widgets/weather_widget.dart';
 
 // Reusable widgets for displaying content and ads
 //import 'package:shorouk_news/widgets/news_card.dart';
@@ -32,6 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadData();
+      context.read<WeatherProvider>().requestWeatherForCurrentLocation();
     });
   }
 
@@ -111,6 +114,21 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 SliverToBoxAdapter(
                   child: _buildSelectedColumnsList(newsProvider),
+                ),
+
+                // Weather widget before most read section
+                SliverToBoxAdapter(
+                  child: Consumer<WeatherProvider>(
+                    builder: (context, weatherProvider, child) {
+                      if (weatherProvider.isLoading) {
+                        return const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
+                      return WeatherWidget(info: weatherProvider.info);
+                    },
+                  ),
                 ),
 
                 // Most Read Stories Section with blue header

--- a/lib/screens/splash/splash_screen.dart
+++ b/lib/screens/splash/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../../core/theme.dart';
 
@@ -68,7 +69,8 @@ class _SplashScreenState extends State<SplashScreen>
     _startAnimations();
 
     // Navigate after 6 seconds
-    Future.delayed(const Duration(seconds: 6), () {
+    Future.delayed(const Duration(seconds: 6), () async {
+      await _requestLocationPermission();
       if (mounted) {
         context.go('/home');
       }
@@ -237,6 +239,13 @@ class _SplashScreenState extends State<SplashScreen>
         ),
       ),
     );
+  }
+
+  Future<void> _requestLocationPermission() async {
+    final status = await Permission.location.request();
+    if (status.isPermanentlyDenied) {
+      await openAppSettings();
+    }
   }
 }
 

--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/weather_model.dart';
+
+class WeatherService {
+  Future<WeatherInfo?> fetchWeather(double lat, double lon) async {
+    final uri = Uri.parse(
+        'https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&current_weather=true');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      return WeatherInfo.fromJson(data);
+    }
+    return null;
+  }
+}

--- a/lib/widgets/weather_widget.dart
+++ b/lib/widgets/weather_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../core/theme.dart';
+import '../models/weather_model.dart';
+
+class WeatherWidget extends StatelessWidget {
+  final WeatherInfo? info;
+  const WeatherWidget({super.key, this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    if (info == null) {
+      return const SizedBox.shrink();
+    }
+    return Container(
+      margin: const EdgeInsets.all(8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
+        boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.wb_sunny, color: AppTheme.primaryColor),
+          const SizedBox(width: 8),
+          Text(
+            '${info!.temperature.toStringAsFixed(1)}°C',
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              fontFamily: 'Cairo',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   video_player: ^2.10.0
   timezone: ^0.10.1
   flutter_local_notifications: ^19.2.1
+  geolocator: ^10.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update dependencies with geolocator
- add Weather provider/service/model and widget
- request location permission on splash screen
- fetch current weather on home load
- display weather widget before the **الأكثر قراءة** section

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68516907c3088321b34a5dc4f70e9b45