### PR TITLE
Integrate author listing via API

### DIFF
--- a/lib/screens/authors/author_module.dart
+++ b/lib/screens/authors/author_module.dart
@@ -270,6 +270,25 @@ class AuthorModule {
     }
   }
 
+  Future<List<AuthorModel>> getAllAuthors({bool forceRefresh = false}) async {
+    if (!forceRefresh && _authorsCache.isNotEmpty) {
+      return _authorsCache.values.toList();
+    }
+    try {
+      final authors = await _apiService.getColumnists();
+      for (final author in authors) {
+        _authorsCache[author.id] = author;
+      }
+      return authors;
+    } catch (e) {
+      debugPrint('Error getting authors list: $e');
+      if (_authorsCache.isNotEmpty) {
+        return _authorsCache.values.toList();
+      }
+      rethrow;
+    }
+  }
+
   // Get author columns with pagination and filtering
   Future<List<ColumnModel>> getAuthorColumns(
     String authorId, {

--- a/lib/screens/authors/authors_list_screen.dart
+++ b/lib/screens/authors/authors_list_screen.dart
@@ -113,9 +113,12 @@ class _AuthorsListScreenState extends State<AuthorsListScreen>
         _errorMessage = null;
       });
 
-      // In a real app, this would be an API call to get all authors
-      // For now, we'll simulate loading authors from cache or create mock data
-      await _loadMockAuthors();
+      try {
+        _allAuthors = await _authorModule.getAllAuthors();
+      } catch (_) {
+        // Fallback to mock data if API fails
+        await _loadMockAuthors();
+      }
       
       // Load favorites and recent authors
       await _loadFavoriteAuthors();

--- a/lib/screens/columns/column_detail_screen.dart
+++ b/lib/screens/columns/column_detail_screen.dart
@@ -413,7 +413,7 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
     }
     if (_relatedColumns.isEmpty) return [];
 
-    final columns = _relatedColumns.take(3).toList();
+    final columns = List<ColumnModel>.from(_relatedColumns);
 
     return [
       SliverToBoxAdapter(
@@ -435,7 +435,7 @@ class _ColumnDetailScreenState extends State<ColumnDetailScreen> {
               margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
               child: ListTile(
                 title: Text(
-                  column.title,
+                  column.title.isNotEmpty ? column.title : column.summary,
                   style: const TextStyle(
                       fontWeight: FontWeight.bold, fontSize: 14),
                   maxLines: 2,

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -544,6 +544,22 @@ class ApiService {
     );
   }
 
+  Future<List<AuthorModel>> getColumnists({
+    int currentPage = 1,
+    int pageSize = 50,
+  }) async {
+    return await _get<List<AuthorModel>>(
+      'columnists/list',
+      queryParameters: {
+        'currentpage': currentPage.toString(),
+        'pagesize': pageSize.toString(),
+      },
+      fromJsonList: (list) => list
+          .map((item) => AuthorModel.fromJson(item as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
   Future<int> subscribeToNewsletter(String email) async {
     try {
       final result = await _post<dynamic>(


### PR DESCRIPTION
## Summary
- add `getColumnists` to `ApiService`
- add `getAllAuthors` in `AuthorModule`
- load authors from the API in `AuthorsListScreen`
- improve related columns list in `ColumnDetailScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685180b1d0388321aa9be059d5778ab8